### PR TITLE
Update Converter.cs

### DIFF
--- a/Moq.To.NSubstitute/Converter.cs
+++ b/Moq.To.NSubstitute/Converter.cs
@@ -106,12 +106,12 @@ public class Converter
         var replacement = "$1.Received(${times})$3";
         var replacedContent = content.RegexReplace(pattern, replacement);
 
-        pattern = @"(?<!\.)\b(\w+)\.Verify\((\w+) => \2(.+?)\)\)";
-        replacement = "$1.Received()$3)";
-        replacedContent = replacedContent.RegexReplace(pattern, replacement);
-
         pattern = @"(?<!\.)\b(\w+)\.Verify\((\w+) => \2(.+?), Times\.Never\)";
         replacement = "$1.DidNotReceive()$3";
+        replacedContent = replacedContent.RegexReplace(pattern, replacement);
+
+        pattern = @"(?<!\.)\b(\w+)\.Verify\((\w+) => \2(.+?)\)\)";
+        replacement = "$1.Received()$3)";
         replacedContent = replacedContent.RegexReplace(pattern, replacement);
 
         return replacedContent;


### PR DESCRIPTION
Fixing conversion for Times.Never broken expressions. Example:

moq expression:
`mock.Verify(x => x.Method(It.IsAny<int>(), It.IsAny<int>()), Times.Never);`

output:
`mock.Received().Method(Arg.Any<int>(), Arg.Any<int>()), Times.Never;`

expected:
`mock.DidNotReceive().Method(Arg.Any<int>(), Arg.Any<int>());`

Solution:
The order in which the regex substitutions are evaluated matters, more specific patterns should be evaluated earlier than more general patterns. Reordering the code fixes the problem.